### PR TITLE
Add surrogate pairs test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -29,6 +29,11 @@ describe('spongebobify', function() {
         assert.equal(result, '!Fh@# @B#CsQ@A');
     });
 
+    it('surrogate pairs', function() {
+        let result = spongebobify('abc𝟘𝟙𝟚𝟛');
+        assert.equal(result, 'aBc𝟘𝟙𝟚𝟛');
+    });
+
     it('emoji', function() {
         let result = spongebobify('🤤😅😫🤶😖🤳💁💓😏🖤');
         assert.equal(result, '🤤😅😫🤶😖🤳💁💓😏🖤');


### PR DESCRIPTION
Tests how the library handles characters with codepoints > 16 bytes. This fails with a for loop or .split('').